### PR TITLE
fix: (ds) Disable renovate for Go deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "gomod": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
Go dependencies must be handled in the upstream repository.

Disable the renovate bot to avoid accidentally merging the bot's PRs.

