### PR TITLE
Replace manual disk cleanup with quick-cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,17 +151,9 @@ jobs:
         deployment: [manifests, helm, operator, systemdmode]
     steps:
       - name: Free Disk Space
-        working-directory: ${{ github.workspace }}
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,17 +55,9 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Free Disk Space
-        working-directory: ${{ github.workspace }}
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -133,17 +125,9 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Free Disk Space
-        working-directory: ${{ github.workspace }}
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
 
       - name: Code checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Replace manual disk cleanup scripts with the shared [`palmsoftware/quick-cleanup`](https://github.com/palmsoftware/quick-cleanup) GitHub Action.

This consolidates 4 identical copy-paste cleanup blocks across 2 workflows into a single maintained action. It also provides automatic Docker storage relocation to the larger `/mnt` partition.

## Already in use

`quick-cleanup` is already adopted in production workflows across multiple repos:

- [`crc-org/crc`](https://github.com/crc-org/crc/blob/main/.github/workflows/make-rpm.yml#L19) — CRC (OpenShift Local)
- [`palmsoftware/quick-ocp`](https://github.com/palmsoftware/quick-ocp/blob/main/action.yml#L94) — OpenShift cluster deployment action
- [`palmsoftware/quick-k8s`](https://github.com/palmsoftware/quick-k8s/blob/main/action.yml#L509) — Kubernetes cluster deployment action (KinD/Minikube)

## Related PRs

- https://github.com/crc-org/crc/pull/5145
- https://github.com/metallb/metallb-operator/pull/537
- https://github.com/prometheus-operator/prometheus-operator/pull/8389
- https://github.com/topolvm/topolvm/pull/1151
- https://github.com/vmware-tanzu/velero/pull/9550




## Tracking

- [palmsoftware/quick-cleanup#3](https://github.com/palmsoftware/quick-cleanup/issues/3) — Tracking issue
- [CNFCERT-1351](https://issues.redhat.com/browse/CNFCERT-1351) — Jira

## Changes

- Updated `.github/workflows/publish.yaml` — replaced 2 "Free Disk Space" blocks
- Updated `.github/workflows/ci.yaml` — replaced 1 "Free Disk Space" block

## Benefits

- **Less boilerplate** — replaces 33 lines of shell commands across 3 locations
- **Docker relocation** — automatically moves Docker storage to `/mnt` (larger partition)
- **Adaptive cleanup** — adjusts intensity based on available space
- **Disk reporting** — built-in before/after `df -h` output
- **Maintained upstream** — cleanup targets updated as runner images change
- **Apache 2.0 licensed**