### PR TITLE
tekton: remove branch references from configuration

### DIFF
--- a/.tekton/openperouter-operator-4-21-pull-request.yaml
+++ b/.tekton/openperouter-operator-4-21-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-4-21

--- a/.tekton/openperouter-operator-4-21-push.yaml
+++ b/.tekton/openperouter-operator-4-21-push.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-4-21

--- a/.tekton/openperouter-operator-bundle-4-21-pull-request.yaml
+++ b/.tekton/openperouter-operator-bundle-4-21-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "operator/***".pathChanged() || ".tekton/openperouter-operator-bundle-4-21-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-4-21

--- a/.tekton/openperouter-operator-bundle-4-21-push.yaml
+++ b/.tekton/openperouter-operator-bundle-4-21-push.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "operator/***".pathChanged() || ".tekton/openperouter-operator-bundle-4-21-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-4-21

--- a/.tekton/openperouter-operator-fbc-4-21-pull-request.yaml
+++ b/.tekton/openperouter-operator-fbc-4-21-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-fbc-4-21

--- a/.tekton/openperouter-operator-fbc-4-21-push.yaml
+++ b/.tekton/openperouter-operator-fbc-4-21-push.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-fbc-4-21


### PR DESCRIPTION
To improve portability and maintanability, Tekton files should not contain references to the branch they work on.

Use glob patterns instead of literal branch names in `pipelinesascode.tekton.dev` annotations.

Links:
- https://pipelinesascode.com/docs/guide/matchingevents/

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
