### PR TITLE
Tekton: fix `check-labels` task

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -4,7 +4,6 @@ entries:
   - defaultChannel: alpha
     name: openperouter-operator
     schema: olm.package
-  # Add 'replaces' after we ship 4.20.0
   - entries:
       - name: openperouter-operator.v4.22.0
         skipRange: '>=4.9.0 <4.22.0'
@@ -17,7 +16,6 @@ entries:
     name: "4.22"
     package: openperouter-operator
     schema: olm.channel  
-    # TODO: update to 4.22 once the bundle image is available
-  - image: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-4-21@sha256:914f2a17a9e791edb34c11187a2402e63759b9ac67c44a25067dd51b76fa2bfe
+  - image: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-4-22@sha256:64cd5e3c920eb8421845a77a604ceca461f51578226a00d36dd64e765be34981
     schema: olm.bundle
 schema: olm.template.basic

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -35,8 +35,7 @@ COPY systemdmode/frrconfig/vtysh.conf /etc/frr/vtysh.conf
 COPY systemdmode/frrconfig/frr.conf /etc/frr/frr.conf
 
 LABEL com.redhat.component="openperouter" \
-    name="openperouter" \
-    version="${CI_CONTAINER_VERSION}" \
+    name="openshift4-dev-preview-beta/openperouter-rhel9-operator" \
     summary="openperouter" \
     io.openshift.expose-services="" \
     io.openshift.tags="openperouter" \
@@ -44,7 +43,7 @@ LABEL com.redhat.component="openperouter" \
     io.k8s.description="openperouter" \
     description="openperouter" \
     distribution-scope="public" \
-    release="4.20" \
+    release="4.22" \
     url="https://github.com/openperouter/openperouter" \
     vendor="Red Hat, Inc."
 


### PR DESCRIPTION
Fix tekton error
```
  Error: Component 'openperouter-operator-4-22' name label ('openperouter') does not match expected name ('openshift4-dev-preview-beta/openperouter-rhel9-operator')
```

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
