### PR TITLE
ds: Improve Tekton pipeline triggering

### DIFF
--- a/.tekton/openperouter-operator-pull-request.yaml
+++ b/.tekton/openperouter-operator-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
-    pipelinesascode.tekton.dev/on-path-change-ignore: "[operator/bundle.Dockerfile.openshift, operator/bundle/**, .konflux/**]"
+    pipelinesascode.tekton.dev/on-path-change-ignore: "[operator/bundle/overlay/pin_images.in.yaml, .konflux/catalog/bundle.builds.in.yaml]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-4-22

--- a/.tekton/openperouter-operator-push.yaml
+++ b/.tekton/openperouter-operator-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
-    pipelinesascode.tekton.dev/on-path-change-ignore: "[operator/bundle.Dockerfile.openshift, operator/bundle/**, .konflux/**]"
+    pipelinesascode.tekton.dev/on-path-change-ignore: "[operator/bundle/overlay/pin_images.in.yaml, .konflux/catalog/bundle.builds.in.yaml]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-4-22


### PR DESCRIPTION
Operator builds must be triggered as much as possible. The only situation to avoid, is that when the images are update by nudge PRs, which happen on files
- operator/bundle/overlay/pin_images.in.yaml
- .konflux/catalog/bundle.builds.in.yaml
