### PR TITLE
Fix syntax error in renovate.json for tekton

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     "jsonnet-bundler": {
         "enabled": false
     },
-    "tekton" {
+    "tekton": {
         "enabled": true,
         "includePaths": [
             ".tekton/**"


### PR DESCRIPTION
The issue has been introduced by
- https://github.com/openshift-kni/openperouter/pull/227
