### PR TITLE
Add packageRules to disable git-submodules updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,12 @@
             "lgtm",
             "ok-to-test"
         ]
-    }
+    },
+    "packageRules": [
+        {
+            "matchManagers": ["git-submodules"],
+            "matchFileNames": ["openshift/**"],
+            "enabled": false
+        }
+    ]
 }


### PR DESCRIPTION
To avoid PRs like
- https://github.com/openshift-kni/openperouter/pull/287

Do not disable the git-submodules package manager entirely, as the `/telko5g-konflux` submodules must be kept updated.
