### PR TITLE
ds: Build bundles on PRs

### DIFF
--- a/.tekton/openperouter-operator-bundle-pull-request.yaml
+++ b/.tekton/openperouter-operator-bundle-pull-request.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main,refs/heads/release-*]"
-    pipelinesascode.tekton.dev/on-path-change: "[operator/bundle.Dockerfile.openshift,operator/bundle/**]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openperouter-operator-5-0
@@ -43,6 +42,9 @@ spec:
     value: 'false'
   - name: image-append-platform
     value: 'false'
+  - name: build-args
+    value:
+    - OPERATOR_IMAGE=quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-5-0:on-pr-{{revision}}
   - name: skip-sast-coverity
     value: 'true'
   pipelineSpec:

--- a/operator/bundle.Dockerfile.openshift
+++ b/operator/bundle.Dockerfile.openshift
@@ -1,16 +1,26 @@
 FROM quay.io/konflux-ci/yq:latest@sha256:466005c667e6e9ea19fd4738275f71a13f89382f6233c581d5e952a41ccb3b42 AS builder
 
+ARG OPERATOR_IMAGE=""
+
 COPY --chown=yq:yq operator/bundle/manifests /manifests/
 COPY --chown=yq:yq operator/bundle/metadata /metadata/
 COPY --chown=yq:yq operator/bundle/overlay/ /overlay/
-COPY telco5g-konflux/scripts/bundle/konflux-bundle-overlay.sh /konflux-bundle-overlay.sh 
+COPY telco5g-konflux/scripts/bundle/konflux-bundle-overlay.sh /konflux-bundle-overlay.sh
 
-RUN /konflux-bundle-overlay.sh  \
-    --set-csv-file /manifests/openperouter-operator.clusterserviceversion.yaml \
-    --set-mapping-file /overlay/map_images.in.yaml \
-    --set-mapping-production \
-    --set-pinning-file /overlay/pin_images.in.yaml \
-    --set-release-file /overlay/release.in.yaml
+RUN if [ -n "$OPERATOR_IMAGE" ]; then \
+      yq -i '(.[] | select(.key == "operator")).target = "'"$OPERATOR_IMAGE"'"' /overlay/pin_images.in.yaml && \
+      /konflux-bundle-overlay.sh \
+        --set-csv-file /manifests/openperouter-operator.clusterserviceversion.yaml \
+        --set-pinning-file /overlay/pin_images.in.yaml \
+        --set-release-file /overlay/release.in.yaml; \
+    else \
+      /konflux-bundle-overlay.sh \
+        --set-csv-file /manifests/openperouter-operator.clusterserviceversion.yaml \
+        --set-mapping-file /overlay/map_images.in.yaml \
+        --set-mapping-production \
+        --set-pinning-file /overlay/pin_images.in.yaml \
+        --set-release-file /overlay/release.in.yaml; \
+    fi
 
 FROM scratch
 


### PR DESCRIPTION
to allow deploy of downstream PR code via:
```
BUNDLE_IMAGE=quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:pr-305

cat <<EOF | oc apply -f -
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-openperouter
EOF

operator-sdk run bundle "$BUNDLE_IMAGE" \
  --namespace openshift-openperouter 
```
