### PR TITLE
openshfit: Fix renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
         "enabled": false
     },
     "tekton": {
-        "enabled": true,
+        "managerFilePatterns": [".tekton/**"],
         "includePaths": [
             ".tekton/**"
         ],

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,7 @@
     "packageRules": [
         {
             "matchManagers": ["git-submodules"],
-            "matchFileNames": ["openshift/**"],
+            "matchPackageNames": ["openshift/**"],
             "enabled": false
         }
     ]


### PR DESCRIPTION
[ds: fix renovate for git submodules](https://github.com/openshift-kni/openperouter/commit/01f829d644998c2b19db71947c735d5326c8b77c)
[ds: fix tekton renovate configuration](https://github.com/openshift-kni/openperouter/commit/a0eb7c97bb47525d94a87125a42c56f891656a00)

Renovate configuration is needed to keep the tekton task updated.