### PR TITLE
ds: add `test` and `edge` bundle push pipeline

### DIFF
--- a/.tekton/openperouter-operator-dev.yaml
+++ b/.tekton/openperouter-operator-dev.yaml
@@ -1,0 +1,540 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/openperouter?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # openshift-merge-robot is the user who aligns the release branches. Don't trigger the pipeline on branch alignments
+    # must also run on each pull request
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" &&
+       body.sender.login != "openshift-merge-robot" &&
+       (target_branch == "main" || target_branch.startsWith("release-"))) ||
+      event == "pull_request"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: openperouter-operator-5-0
+    appstudio.openshift.io/component: openperouter-operator-bundle-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: openperouter-operator-bundle-dev
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:test-{{revision}}
+  - name: output-image-edge
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:edge-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: operator/bundle.Dockerfile.openshift
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: build-source-image
+    value: 'false'
+  - name: image-append-platform
+    value: 'false'
+  - name: pull-request-number
+    value: '{{pull_request_number}}'
+  - name: skip-checks
+    value: 'true'
+  pipelineSpec:
+    description: |
+      Builds two operator bundle variants (test and edge) from the same Dockerfile,
+      each pinning a different OPERATOR_IMAGE.
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image (test variant)
+      name: output-image
+      type: string
+    - description: Fully Qualified Output Image (edge variant)
+      name: output-image-edge
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote VMs
+      name: privileged-nested
+      type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    - name: buildah-format
+      default: docker
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
+    - default: ""
+      description: Pull request number, empty for push events
+      name: pull-request-number
+      type: string
+    results:
+    - description: "Test bundle image URL"
+      name: IMAGE_URL
+      value: $(tasks.build-image-index-test.results.IMAGE_URL)
+    - description: "Test bundle image digest"
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index-test.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    # ── Shared tasks ──────────────────────────────────────────────────
+    - name: init
+      params:
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: generate-labels
+      params:
+      - name: label-templates
+        value:
+        - build-date=$SOURCE_DATE
+        - short-commit=$(tasks.clone-repository.results.short-commit)
+        - version=v5.0-$SOURCE_DATE_EPOCH
+      - name: source-date-epoch
+        value: $(tasks.clone-repository.results.commit-timestamp)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: generate-labels
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:73327724d44fd4974ebd849fa753b5e8e7a21e814fdc0d975ce8649b0a540dba
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: resolve-operator-images
+      params:
+      - name: PULL_REQUEST_NUMBER
+        value: $(params.pull-request-number)
+      - name: REVISION
+        value: $(params.revision)
+      runAfter:
+      - init
+      taskSpec:
+        params:
+        - name: PULL_REQUEST_NUMBER
+          type: string
+        - name: REVISION
+          type: string
+        results:
+        - name: OPERATOR_IMAGE_TEST
+        - name: OPERATOR_IMAGE_EDGE
+        - name: PR_TAG_TEST
+        - name: PR_TAG_EDGE
+        steps:
+        - image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+          script: |
+            if [ -n "$(params.PULL_REQUEST_NUMBER)" ]; then
+              OPERATOR_IMAGE_TAG="on-pr-$(params.REVISION)"
+              echo -n "test-pr-$(params.PULL_REQUEST_NUMBER)" > $(results.PR_TAG_TEST.path)
+              echo -n "edge-pr-$(params.PULL_REQUEST_NUMBER)" > $(results.PR_TAG_EDGE.path)
+            else
+              OPERATOR_IMAGE_TAG="$(params.REVISION)"
+              echo -n "" > $(results.PR_TAG_TEST.path)
+              echo -n "" > $(results.PR_TAG_EDGE.path)
+            fi
+            echo -n "quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-5-0:${OPERATOR_IMAGE_TAG}" > $(results.OPERATOR_IMAGE_TEST.path)
+            echo -n "quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-edge-5-0:${OPERATOR_IMAGE_TAG}" > $(results.OPERATOR_IMAGE_EDGE.path)
+    # ── Test bundle build chain ───────────────────────────────────────
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images-test
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - OPERATOR_IMAGE=$(tasks.resolve-operator-images.results.OPERATOR_IMAGE_TEST)
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      - name: LABELS
+        value:
+        - $(tasks.generate-labels.results.labels[*])
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:1eaac50bb7e77feccfe3f0a521714de6a153387d3847bd94542e2a974bb05121
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index-test
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images-test.results.IMAGE_REF[*])
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-images-test
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: apply-tags-test
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index-test.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index-test.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: ["test-latest"]
+      runAfter:
+      - build-image-index-test
+      when:
+      - input: $(params.pull-request-number)
+        operator: in
+        values:
+        - ""
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: apply-tags-test-pr
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index-test.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index-test.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - $(tasks.resolve-operator-images.results.PR_TAG_TEST)
+      runAfter:
+      - build-image-index-test
+      when:
+      - input: $(params.pull-request-number)
+        operator: notin
+        values:
+        - ""
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+        - name: kind
+          value: task
+        resolver: bundles
+    # ── Edge bundle build chain ───────────────────────────────────────
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images-edge
+      params:
+      - name: IMAGE
+        value: $(params.output-image-edge)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - OPERATOR_IMAGE=$(tasks.resolve-operator-images.results.OPERATOR_IMAGE_EDGE)
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      - name: LABELS
+        value:
+        - $(tasks.generate-labels.results.labels[*])
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:1eaac50bb7e77feccfe3f0a521714de6a153387d3847bd94542e2a974bb05121
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index-edge
+      params:
+      - name: IMAGE
+        value: $(params.output-image-edge)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images-edge.results.IMAGE_REF[*])
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-images-edge
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: apply-tags-edge
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index-edge.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index-edge.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: ["edge-latest"]
+      runAfter:
+      - build-image-index-edge
+      when:
+      - input: $(params.pull-request-number)
+        operator: in
+        values:
+        - ""
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: apply-tags-edge-pr
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index-edge.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index-edge.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - $(tasks.resolve-operator-images.results.PR_TAG_EDGE)
+      runAfter:
+      - build-image-index-edge
+      when:
+      - input: $(params.pull-request-number)
+        operator: notin
+        values:
+        - ""
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+        - name: kind
+          value: task
+        resolver: bundles
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openperouter-operator-bundle-5-0
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add a PipelineRun that builds two operator bundle variants on every
push to main/release-* branches, and PRs, pinning different OPERATOR_IMAGE
build args:
- `test-latest`, `test-<revision>`: pins the standard operator image
- `edge-latest`, `edge-<revision>`: pins the edge operator image

also push moving tags `test-latest` and `edge-latest`.

On PRs, bundle images are available with tags:
- `test-pr-NNN`, `test-<revision>`
- `edge-pr-NNN`, `edge-<revision>`

as a summary, new images available are:
on `main/release-*` branches:
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:test-<revision>`
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:test-latest`
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:edge-<revision>`
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:edge-latest`

on PRs:
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:test-<revision>`
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:test-pr-NNN`
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:edge-<revision>`
- `quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0:edge-pr-NNN`

