### PR TITLE
Add CPE information for OpenShift 4.22

### DIFF
--- a/operator/bundle.Dockerfile.openshift
+++ b/operator/bundle.Dockerfile.openshift
@@ -34,6 +34,7 @@ LABEL com.redhat.component="openperouter-operator" \
     distribution-scope="public" \
     release="4.22" \
     url="https://github.com/openperouter/openperouter" \
+    cpe=cpe:/a:redhat:openshift:4.22::el9 \
     vendor="Red Hat, Inc."
 
 COPY --from=builder /manifests/ /manifests/


### PR DESCRIPTION
This label fixes the `openperouter-operator-conforma-staging-4-22` :
```
✕ [Violation] labels.required_labels
  ImageRef: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-4-22@sha256:2f376be0ad53a455310e1db148fdcbac3072e02b9e78aee419791815f9b3f866
  Reason: The required "cpe" label is missing. Label description: The CPE (Common Platform Enumeration) identifier for the
  product, e.g., cpe:/a:redhat:openshift_gitops:1.16::el8. This label is required for on-prem product releases.
  Term: cpe
  Title: Required labels
  Description: Check the image for the presence of labels that are required. Use the rule data `required_labels` key to set the
  list of labels to check, or the `fbc_required_labels` key for fbc images. To exclude this rule add "labels.required_labels:cpe"
  to the `exclude` section of the policy configuration.
  Solution: Update the image build process to set the required labels.
```
