### PR TITLE
Restore go 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openperouter/openperouter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0


### PR DESCRIPTION
Reverting the temporary commit
- https://github.com/openshift-kni/openperouter/commit/4e5024674bcfe3221519d5db9ce9b32da1133bdb

as the Go version is now available on openshfit 5.0
- https://github.com/openshift-eng/ocp-build-data/pull/11758
