### PR TITLE
OpenShift only: add frr-reload patch to Dockerfile.openshift

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -51,6 +51,10 @@ COPY systemdmode/frrconfig/daemons /etc/frr/daemons
 COPY systemdmode/frrconfig/vtysh.conf /etc/frr/vtysh.conf
 COPY systemdmode/frrconfig/frr.conf /etc/frr/frr.conf
 
+# Hack for https://github.com/FRRouting/frr/issues/20355
+#          https://github.com/FRRouting/frr/pull/20378
+COPY openshift/frr-reload.py.patched /usr/lib/frr/frr-reload.py
+
 LABEL com.redhat.component="openperouter" \
     name="openshift4-dev-preview-beta/openperouter-rhel9-operator" \
     summary="openperouter" \


### PR DESCRIPTION
We add the fix to the ocp build the same as the other Dockerfiles.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://https://openperouter.github.io/docs/contributing/)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/openperouter/openperouter/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression
> /kind example

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```

**AI Guidelines Acknowledgment**:

- [ ] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.
