### PR TITLE
Add certsuite-test-bundle for Konflux certsuite testing

### DIFF
--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,5 +1,6 @@
 ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
 
+# noop: touch path so Konflux FBC PR pipeline (on-path-change: .konflux/**) runs
 FROM ${OPM_IMAGE}
 
 # ensure this correponds to olm.package name

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,3 +1,3 @@
 ---
 # When we are ready to ship the first Konflux release, replace this with the nudge to the quay build
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0@sha256:68be55f264fe43195b6996998e74a051c1e27460e812bff973b8b5769d672040
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0@sha256:b31472173c902243b542be080c9caf1dc14ef2a8ba187fd4f5effc0313b059d9

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -12,3 +12,6 @@ spec:
     - mirrors:
         - quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-bundle-5-0
       source: registry.redhat.io/openshift4-dev-preview-beta/openperouter-operator-bundle
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/openperouter-operator-edge-5-0
+      source: registry.redhat.io/openshift4-dev-preview-beta/openperouter-edge-rhel10-operator

--- a/certsuite-test-bundle/certsuite-test-bundle.yaml
+++ b/certsuite-test-bundle/certsuite-test-bundle.yaml
@@ -1,0 +1,27 @@
+apiVersion: certsuite.redhat.com/v1alpha1
+kind: TestBundle
+metadata:
+  name: openperouter-test-bundle
+  labels:
+    app.kubernetes.io/part-of: openperouter
+spec:
+  namespace: openperouter-system
+
+  description: |
+    Software-only test deployment of openperouter-operator operands. Creates an
+    OpenPERouter CR that exercises the operator's reconciliation logic and
+    deploys the controller DaemonSet, router DaemonSet, and nodemarker
+    Deployment without requiring specialized networking hardware. Network CRs
+    (Underlay, L3VNI, etc.) are omitted because they depend on real NICs.
+
+  readiness:
+    timeout: 300
+    checks:
+      - kind: DaemonSet
+        name: controller
+      - kind: DaemonSet
+        name: router
+      - kind: Deployment
+        name: nodemarker
+      - kind: OpenPERouter
+        name: openperouter

--- a/certsuite-test-bundle/certsuite-test-bundle.yaml
+++ b/certsuite-test-bundle/certsuite-test-bundle.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: openperouter
 spec:
+  # Must match operand + certsuite_config targetNameSpaces. OwnNamespace avoids
+  # the resolver preferring AllNamespaces (both are supported on the CSV) and
+  # falling through to a generated oo-* install namespace.
   namespace: openperouter-system
+  installMode: OwnNamespace
 
   description: |
     Software-only test deployment of openperouter-operator operands. Creates an

--- a/certsuite-test-bundle/certsuite_config.yml
+++ b/certsuite-test-bundle/certsuite_config.yml
@@ -1,0 +1,12 @@
+targetNameSpaces:
+  - name: openperouter-system
+
+podsUnderTestLabels:
+  - "redhat-best-practices-for-k8s.com/generic: target"
+
+operatorsUnderTestLabels:
+  - "redhat-best-practices-for-k8s.com/operator: target"
+
+targetCrdFilters:
+  - nameSuffix: "network.openperouter.io"
+    scalable: false

--- a/certsuite-test-bundle/operands/openperouter.yaml
+++ b/certsuite-test-bundle/operands/openperouter.yaml
@@ -7,7 +7,9 @@ apiVersion: network.openperouter.io/v1alpha1
 kind: OpenPERouter
 metadata:
   name: openperouter
-  namespace: openperouter-system
+  # Namespace omitted so `oc apply -n <install-ns>` from konflux-certsuite works.
+  # Target namespace comes from certsuite-test-bundle.yaml spec.namespace
+  # (openperouter-system).
 spec:
   logLevel: info
   runOnMaster: false

--- a/certsuite-test-bundle/operands/openperouter.yaml
+++ b/certsuite-test-bundle/operands/openperouter.yaml
@@ -1,0 +1,13 @@
+# OpenPERouter CR for software-only certsuite testing.
+#
+# Creates the controller DaemonSet, router DaemonSet, and nodemarker
+# Deployment. runOnMaster is false so workloads schedule on worker-only
+# HyperShift EaaS guest clusters.
+apiVersion: network.openperouter.io/v1alpha1
+kind: OpenPERouter
+metadata:
+  name: openperouter
+  namespace: openperouter-system
+spec:
+  logLevel: info
+  runOnMaster: false


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind feature

**What this PR does / why we need it**:

Adds a generic `certsuite-test-bundle/` so Konflux certsuite (EaaS) can deploy a software-only OpenPERouter configuration for operator testing. Also mirrors the edge image in `.tekton/images-mirror-set.yaml` for unreleased pulls.

**Special notes for your reviewer**:

- Operand sets `runOnMaster: false` for HyperShift worker-only guests
- Draft while wiring the optional `konflux-certsuite` IntegrationTestScenario in konflux-release-data

**Release note**:

```release-note
NONE
```

**AI Guidelines Acknowledgment**:

- [x] I have reviewed all changes in this PR, including any AI-generated content, and I take full responsibility for its accuracy and correctness.

## Summary
- Add `certsuite-test-bundle/` with OpenPERouter CR + certsuite_config.yml
- Extend images-mirror-set with edge image

## Test plan
- [x] validate-test-bundle.sh passes
- [ ] Optional Konflux ITS consumes this branch via TEST_BUNDLE_REF

Assisted-By: Cursor